### PR TITLE
Add flake.nix and rename `libSoftwareCounters.so` -> `libSoftwareCountersClang.so`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ third-party/zen-pmu-workaround/*.mod
 third-party/zen-pmu-workaround/*.mod.c
 third-party/zen-pmu-workaround/Module.symvers
 third-party/zen-pmu-workaround/modules.order
+result
 rr_trace.capnp.*
 test32.c
 src/preload/rr_page.ld

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ set(SOFTWARE_COUNTERS_PLUGIN "" CACHE PATH "file location of clang compiler plug
 if ("${SOFTWARE_COUNTERS_PLUGIN}" STREQUAL "")
   message(FATAL_ERROR "Cannot set SOFTWARE_COUNTERS_PLUGIN to empty string, \
                        please set to valid plugin file with full path. For example: \
-                       ~/libSoftwareCounters.so")
+                       ~/libSoftwareCountersClang.so if using clang & clang++ to compile \
+                       or ~/libSoftwareCountersGcc.so if using gcc & g++ to compile")
 endif()
 
 set(SOFTWARE_COUNTERS_STATICALLY_INSTRUMENT_TESTS OFF CACHE BOOL "\

--- a/compiler-plugins/SoftwareCountersClangPlugin/CMakeLists.txt
+++ b/compiler-plugins/SoftwareCountersClangPlugin/CMakeLists.txt
@@ -18,9 +18,9 @@ if(NOT LLVM_ENABLE_RTTI)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif()
 
-add_library(SoftwareCounters SHARED SoftwareCounters.cpp)
+add_library(SoftwareCountersClang SHARED SoftwareCounters.cpp)
 
-set(SC_COMMON_FLAGS "-O0 -g -fpass-plugin=${CMAKE_CURRENT_BINARY_DIR}/libSoftwareCounters.so")
+set(SC_COMMON_FLAGS "-O0 -g -fpass-plugin=${CMAKE_CURRENT_BINARY_DIR}/libSoftwareCountersClang.so")
 
 set(INSTRUMENT_THESE
     testCounter
@@ -31,7 +31,7 @@ foreach( instrument_this ${INSTRUMENT_THESE} )
     add_executable(${instrument_this} "${instrument_this}.c")
     set_source_files_properties("${instrument_this}.c" PROPERTIES
                                 COMPILE_FLAGS ${SC_COMMON_FLAGS}
-                                OBJECT_DEPENDS SoftwareCounters)
+                                OBJECT_DEPENDS SoftwareCountersClang)
 
     add_custom_target("${instrument_this}.ll"
                       COMMENT "Generating ${instrument_this}.ll"
@@ -45,7 +45,7 @@ foreach( instrument_this ${INSTRUMENT_THESE} )
     add_custom_target("${instrument_this}Opt.ll"
                       COMMENT "Generating ${instrument_this}Opt.ll"
                       COMMAND opt
-                              -load-pass-plugin=${CMAKE_CURRENT_BINARY_DIR}/libSoftwareCounters.so
+                              -load-pass-plugin=${CMAKE_CURRENT_BINARY_DIR}/libSoftwareCountersClang.so
                               -S -passes="software-counters"
                               -o ${CMAKE_CURRENT_BINARY_DIR}/"${instrument_this}Opt.ll"
                               ${CMAKE_CURRENT_BINARY_DIR}/"${instrument_this}.ll"

--- a/compiler-plugins/SoftwareCountersClangPlugin/Makefile
+++ b/compiler-plugins/SoftwareCountersClangPlugin/Makefile
@@ -24,7 +24,7 @@ compile_commands: cmake
 check: test
 
 install: cmake
-	cp build/libSoftwareCounters.so $(INSTALL_PATH)
+	cp build/libSoftwareCountersClang.so $(INSTALL_PATH)
 
 #--------------------------------
 %Opt.ll: %.ll cmake

--- a/compiler-plugins/SoftwareCountersClangPlugin/README.md
+++ b/compiler-plugins/SoftwareCountersClangPlugin/README.md
@@ -25,16 +25,16 @@ how to build and use this plugin.
 
 ## Usage
 
-_After building the plugin (`libSoftwareCounters.so`):_
+_After building the plugin (`libSoftwareCountersClang.so`):_
 
 ```bash
-# Static instrumentation using the libSoftwareCounters.so plugin
+# Static instrumentation using the libSoftwareCountersClang.so plugin
 # Assume the plugin is stored in $HOME for the purposes of this example
-$ clang -fpass-plugin=$HOME/libSoftwareCounters.so -g -O2 -o hello.c hello.c
+$ clang -fpass-plugin=$HOME/libSoftwareCountersClang.so -g -O2 -o hello.c hello.c
 
 # Works with C++ also
 # Assume the plugin is stored in ~/ for the purposes of this example
-$ clang++ -fpass-plugin=$HOME/libSoftwareCounters.so -g -O2 -o hello hello.cpp
+$ clang++ -fpass-plugin=$HOME/libSoftwareCountersClang.so -g -O2 -o hello hello.cpp
 
 # Executable will work normally, might be a bit slower
 $ ./hello

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,18 +34,21 @@
                 #pkgs.gdb
                 #pkgs.lldb
               ] ++ prev.nativeBuildInputs;
-              buildInputs = [
-                pkgs.bzip2
-                pkgs.zstd
-                pkgs.lz4
-                pkgs.snappy
-                pkgs.rocksdb
-                pkgs.python3Packages.pexpect
-                pkgs.gdb
-                pkgs.lldb
-                self'.packages.libSoftwareCountersGcc
-                self'.packages.libSoftwareCounters
-              ] ++ prev.buildInputs;
+              buildInputs =
+                [
+                  pkgs.bzip2
+                  pkgs.zstd
+                  pkgs.lz4
+                  pkgs.snappy
+                  pkgs.rocksdb
+                  pkgs.python3Packages.pexpect
+                  pkgs.gdb
+                  pkgs.lldb
+                  self'.packages.libSoftwareCountersGcc
+                  self'.packages.libSoftwareCounters
+                ]
+                ++ pkgs.lib.optionals (system == "x86_64-linux") [ pkgs.zydis ]
+                ++ prev.buildInputs;
               # Removed it from flake, no problems
               preConfigure = "";
               cmakeFlags = prev.cmakeFlags ++ [

--- a/flake.nix
+++ b/flake.nix
@@ -105,9 +105,11 @@
               ];
               installPhase = ''
                 mkdir -p $out/lib64
-                mkdir -p $out/share/doc/libSoftwareCounters
-                cp $src/compiler-plugins/SoftwareCountersClangPlugin/LICENSE $out/share/doc/libSoftwareCounters
-                cp libSoftwareCounters.so $out/lib64
+                mkdir -p $out/share/doc/libSoftwareCountersClang
+                cp $src/compiler-plugins/SoftwareCountersClangPlugin/LICENSE $out/share/doc/libSoftwareCountersClang
+                cp libSoftwareCountersClang.so $out/lib64
+                # provide an alias to make things easy when building rr.soft
+                ln -s $out/lib64/libSoftwareCountersClang.so $out/lib64/libSoftwareCounters.so
               '';
               meta = {
                 homepage = "https://github.com/sidkshatriya/rr.soft";

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           rr_compiled_with =
             flavor: software_counters_plugin:
             pkgs.rr.overrideAttrs (prev: {
-              version = "post5.9.0+${flavor}-soft";
+              version = "soft-post5.9.0+builtwith${flavor}";
               src = ./.;
               nativeBuildInputs = [
                 pkgs.pkg-config
@@ -44,8 +44,8 @@
                   pkgs.python3Packages.pexpect
                   pkgs.gdb
                   pkgs.lldb
-                  self'.packages.libSoftwareCountersGcc
-                  self'.packages.libSoftwareCounters
+                  (libSoftwareCountersGccFor "14" pkgs.gcc14Stdenv)
+                  (libSoftwareCountersFor "19" pkgs.clang19Stdenv pkgs.llvmPackages_19)
                 ]
                 ++ pkgs.lib.optionals (system == "x86_64-linux") [ pkgs.zydis ]
                 ++ prev.buildInputs;
@@ -91,7 +91,7 @@
           libSoftwareCountersFor =
             ver: clangStdenvArg: llvmPackagesArg:
             clangStdenvArg.mkDerivation {
-              pname = "libSoftwareCounters${ver}";
+              pname = "libSoftwareCountersClang${ver}";
               version = "0.1";
               src = ./.;
               nativeBuildInputs = [
@@ -122,28 +122,26 @@
             };
         in
         {
-          packages.rr-gcc =
+          packages.rr-builtwithgcc =
             (rr_compiled_with "gcc" (libSoftwareCountersGccFor "14" pkgs.gcc14Stdenv)).override
               {
                 stdenv = pkgs.gcc14Stdenv;
               };
-          packages.rr-clang =
+          packages.rr-builtwithclang =
             (rr_compiled_with "clang" (libSoftwareCountersFor "19" pkgs.clang19Stdenv pkgs.llvmPackages_19))
             .override
               {
                 stdenv = pkgs.clang19Stdenv;
               };
-          packages.rr = self'.packages.rr-clang;
+          packages.rr = self'.packages.rr-builtwithclang;
           packages.libSoftwareCountersGcc14 = (libSoftwareCountersGccFor "14" pkgs.gcc14Stdenv);
           packages.libSoftwareCountersGcc13 = (libSoftwareCountersGccFor "13" pkgs.gcc13Stdenv);
-          packages.libSoftwareCountersGcc = self'.packages.libSoftwareCountersGcc14;
-          packages.libSoftwareCounters19 = (
+          packages.libSoftwareCountersClang19 = (
             libSoftwareCountersFor "19" pkgs.clang19Stdenv pkgs.llvmPackages_19
           );
-          packages.libSoftwareCounters18 = (
+          packages.libSoftwareCountersClang18 = (
             libSoftwareCountersFor "18" pkgs.clang18Stdenv pkgs.llvmPackages_18
           );
-          packages.libSoftwareCounters = self'.packages.libSoftwareCounters19;
           packages.default = self'.packages.rr;
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           ...
         }:
         let
-          rr_preload_compiled_with =
+          rr_compiled_with =
             flavor: software_counters_plugin:
             pkgs.rr.overrideAttrs (prev: {
               version = "post5.9.0+${flavor}-soft";
@@ -118,8 +118,8 @@
           };
         in
         {
-          packages.rr-gcc = (rr_preload_compiled_with "gcc" libSoftwareCountersGcc);
-          packages.rr-clang = (rr_preload_compiled_with "clang" libSoftwareCounters).override {
+          packages.rr-gcc = (rr_compiled_with "gcc" libSoftwareCountersGcc);
+          packages.rr-clang = (rr_compiled_with "clang" libSoftwareCounters).override {
             stdenv = pkgs.clang19Stdenv;
           };
           packages.rr = self'.packages.rr-clang;

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,8 @@
               '';
               installPhase = ''
                 mkdir -p $out/lib64
+                mkdir -p $out/share/doc/libSoftwareCountersGcc
+                cp compiler-plugins/SoftwareCountersGccPlugin/COPYING $out/share/doc/libSoftwareCountersGcc
                 cp compiler-plugins/SoftwareCountersGccPlugin/libSoftwareCountersGcc.so $out/lib64
                 # provide an alias to make things easy when building rr.soft
                 ln -s $out/lib64/libSoftwareCountersGcc.so $out/lib64/libSoftwareCounters.so
@@ -103,6 +105,8 @@
               ];
               installPhase = ''
                 mkdir -p $out/lib64
+                mkdir -p $out/share/doc/libSoftwareCounters
+                cp $src/compiler-plugins/SoftwareCountersClangPlugin/LICENSE $out/share/doc/libSoftwareCounters
                 cp libSoftwareCounters.so $out/lib64
               '';
               meta = {

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,6 @@
                   pkgs.python3Packages.pexpect
                   pkgs.gdb
                   pkgs.lldb
-                  (libSoftwareCountersGccFor "14" pkgs.gcc14Stdenv)
-                  (libSoftwareCountersFor "19" pkgs.clang19Stdenv pkgs.llvmPackages_19)
                 ]
                 ++ pkgs.lib.optionals (system == "x86_64-linux") [ pkgs.zydis ]
                 ++ prev.buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,128 @@
+{
+  description = "rr debugger with software counters support: https://github.com/sidkshatriya/rr.soft";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      perSystem =
+        {
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          ...
+        }:
+        let
+          rr_preload_compiled_with =
+            flavor: software_counters_plugin:
+            pkgs.rr.overrideAttrs (prev: {
+              version = "post5.9.0+${flavor}-soft";
+              src = ./.;
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                pkgs.ninja
+                #pkgs.gdb
+                #pkgs.lldb
+              ] ++ prev.nativeBuildInputs;
+              buildInputs = [
+                pkgs.bzip2
+                pkgs.zstd
+                pkgs.lz4
+                pkgs.snappy
+                pkgs.rocksdb
+                pkgs.python3Packages.pexpect
+                pkgs.gdb
+                pkgs.lldb
+                self'.packages.libSoftwareCountersGcc
+                self'.packages.libSoftwareCounters
+              ] ++ prev.buildInputs;
+              # Removed it from flake, no problems
+              preConfigure = "";
+              cmakeFlags = prev.cmakeFlags ++ [
+                "-DCMAKE_PREFIX_PATH=${pkgs.rocksdb};${pkgs.snappy.dev}"
+                "-DSOFTWARE_COUNTERS_PLUGIN=${software_counters_plugin}/lib/libSoftwareCounters.so"
+                "-GNinja"
+              ];
+              dontStrip = true;
+            });
+          libSoftwareCountersGcc = pkgs.stdenv.mkDerivation {
+            pname = "libSoftwareCountersGcc";
+            version = "0.1";
+            src = ./.;
+            dontConfigure = true;
+            buildInputs = [ pkgs.gmp ];
+            buildPhase = ''
+              make -C ./compiler-plugins/SoftwareCountersGccPlugin/
+            '';
+            installPhase = ''
+              mkdir -p $out/lib64
+              cp compiler-plugins/SoftwareCountersGccPlugin/libSoftwareCountersGcc.so $out/lib64
+              # provide an alias to make things easy when building rr.soft
+              ln -s $out/lib64/libSoftwareCountersGcc.so $out/lib64/libSoftwareCounters.so
+            '';
+            meta = {
+              homepage = "https://github.com/sidkshatriya/rr.soft";
+              description = "libSoftwareCountersGcc";
+
+              license = with pkgs.lib.licenses; [
+                gpl3Plus
+              ];
+              platforms = [
+                "aarch64-linux"
+                "x86_64-linux"
+              ];
+            };
+          };
+          libSoftwareCounters = pkgs.clang19Stdenv.mkDerivation {
+            pname = "libSoftwareCounters";
+            version = "0.1";
+            src = ./.;
+            nativeBuildInputs = [
+              pkgs.cmake
+              pkgs.ninja
+              pkgs.llvmPackages_19.libllvm
+            ];
+            cmakeFlags = [
+              ''-S=${./.}/compiler-plugins/SoftwareCountersClangPlugin''
+              "-GNinja"
+            ];
+            installPhase = ''
+              mkdir -p $out/lib64
+              cp libSoftwareCounters.so $out/lib64
+            '';
+            meta = {
+              homepage = "https://github.com/sidkshatriya/rr.soft";
+              description = "libSoftwareCounters";
+
+              license = with pkgs.lib.licenses; [
+                asl20
+              ];
+              platforms = [
+                "aarch64-linux"
+                "x86_64-linux"
+              ];
+            };
+          };
+        in
+        {
+          packages.rr-gcc = (rr_preload_compiled_with "gcc" libSoftwareCountersGcc);
+          packages.rr-clang = (rr_preload_compiled_with "clang" libSoftwareCounters).override {
+            stdenv = pkgs.clang19Stdenv;
+          };
+          packages.rr = self'.packages.rr-clang;
+          packages.libSoftwareCountersGcc = libSoftwareCountersGcc;
+          packages.libSoftwareCounters = libSoftwareCounters;
+          packages.default = self'.packages.rr;
+        };
+    };
+}


### PR DESCRIPTION
- Add `flake.nix` -- this will allow `rr.soft` to be able to be built and run in many more environments
- Rename  `libSoftwareCounters.so` -> `libSoftwareCountersClang.so` to prevent confusion which compiler the plugin is for