### PR TITLE
Modify compiler plugins to add a `.rr.soft.instrumented` ELF section to indicate file is instrumented

### DIFF
--- a/compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp
+++ b/compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp
@@ -400,8 +400,11 @@ struct SoftwareCounters : PassInfoMixin<SoftwareCounters> {
       }
     }
 
+    // Even if no function ends up getting instrumented in the module, the code should
+    // not be considered for dynamic instrumentation anymore -- indicate this by adding
+    // a .note.rr.soft ELF section
+    InsertSoftNoteGlobalVar(C, M);
     if (InstrumentedAFunction) {
-      InsertSoftNoteGlobalVar(C, M);
       InsertSoftCounterEnableGlobal(C, M);
       // Now insert the software counter function definition that does the
       // counting

--- a/compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp
+++ b/compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp
@@ -25,6 +25,7 @@
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/Transforms/Utils/ModuleUtils.h>
 
 #include <stdlib.h>
 
@@ -68,11 +69,11 @@ void InsertSoftNoteGlobalVar(LLVMContext &C, Module &M) {
   SectionVar->setConstant(true);
   SectionVar->setSection(".rr.soft.instrumented");
   SectionVar->setVisibility(GlobalValue::HiddenVisibility);
-  SectionVar->addAttribute("used");
   auto comdat = M.getOrInsertComdat("__rr_soft_note");
   comdat->setSelectionKind(Comdat::SelectionKind::Any);
   SectionVar->setComdat(comdat);
   SectionVar->setInitializer(ConstantInt::get(Int32Ty, 1));
+  appendToUsed(M, SectionVar);
 }
 
 void InsertCounterFunctionWithDefinitionAArch64(LLVMContext &C, Module &M,

--- a/compiler-plugins/SoftwareCountersGccPlugin/plugin.cpp
+++ b/compiler-plugins/SoftwareCountersGccPlugin/plugin.cpp
@@ -276,7 +276,6 @@ static void _insert_soft_elf_section() {
   TREE_READONLY(soft_elf_section_var) = 1;
   // set the ELF section of the node
   set_decl_section_name(soft_elf_section_var, ".note.rr.soft");
-  DECL_WEAK(soft_elf_section_var) = 1;
   // defined here
   DECL_EXTERNAL(soft_elf_section_var) = 0;
   DECL_ARTIFICIAL(soft_elf_section_var) = 1;
@@ -299,6 +298,8 @@ static void _insert_soft_elf_section() {
   DECL_CONTEXT(soft_elf_section_var) = NULL_TREE;
   layout_decl(soft_elf_section_var, 0);
   auto node = varpool_node::get_create(soft_elf_section_var);
+  DECL_COMDAT(soft_elf_section_var) = 1;
+  node->set_comdat_group(DECL_ASSEMBLER_NAME(soft_elf_section_var));
   node->finalize_decl(soft_elf_section_var);
   // This is necessary
   node->force_output = 1;

--- a/compiler-plugins/SoftwareCountersGccPlugin/plugin.cpp
+++ b/compiler-plugins/SoftwareCountersGccPlugin/plugin.cpp
@@ -259,11 +259,9 @@ static void _insert_soft_elf_section() {
   if (soft_elf_section_var) {
     return;
   }
-  auto index_type = build_index_type(size_int(24 - 1));
-  auto section_char_array_type = build_array_type(char_type_node, index_type);
   soft_elf_section_var =
       build_decl(UNKNOWN_LOCATION, VAR_DECL, get_identifier(SOFT_ELF_SECTION),
-                 section_char_array_type);
+                 integer_type_node);
 
   // Available from other translation units
   TREE_PUBLIC(soft_elf_section_var) = 1;
@@ -275,25 +273,18 @@ static void _insert_soft_elf_section() {
   // Need this for section to marked as allocatable only
   TREE_READONLY(soft_elf_section_var) = 1;
   // set the ELF section of the node
-  set_decl_section_name(soft_elf_section_var, ".note.rr.soft");
+  set_decl_section_name(soft_elf_section_var, ".rr.soft.instrumented");
   // defined here
   DECL_EXTERNAL(soft_elf_section_var) = 0;
   DECL_ARTIFICIAL(soft_elf_section_var) = 1;
   DECL_VISIBILITY(soft_elf_section_var) = VISIBILITY_HIDDEN;
   DECL_VISIBILITY_SPECIFIED(soft_elf_section_var) = 1;
-  // array should alignment of 4 bytes
+  // Should have alignment of 4 bytes
   DECL_USER_ALIGN(soft_elf_section_var) = 1;
   SET_DECL_ALIGN(soft_elf_section_var, 4 * 8);
   // Initialization
-  const char soft_note_data[] = {8, 0, 0, 0, 1, 0, 0, 0,
-                                 1, 0, 0, 0, 'r', 'r', '.', 's',
-                                 'o', 'f', 't', 0, 1, 0, 0, 0};
-  vec<tree, va_gc> *init_vec = NULL;
-  for (int i = 0; i < 24; i++) {
-    vec_safe_push(init_vec, build_int_cst(char_type_node, soft_note_data[i]));
-  }
-  auto init_tree = build_constructor_from_vec(section_char_array_type, init_vec);
-  DECL_INITIAL(soft_elf_section_var) = init_tree;
+  const uint32_t soft_elf_section_var_data = 1;
+  DECL_INITIAL(soft_elf_section_var) = build_int_cst(integer_type_node, soft_elf_section_var_data);
 
   DECL_CONTEXT(soft_elf_section_var) = NULL_TREE;
   layout_decl(soft_elf_section_var, 0);

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -2632,12 +2632,14 @@ void Monkeypatcher::software_counter_instrument_after_mmap(
 
   auto it = t.session().patchdb_map.find(unique_id);
   if (it == t.session().patchdb_map.end()) {
-    // Can now do without symbols on x86-64 and aarch64.
-    //
-    // However need this for for now to check if executable has already been statically
-    // instrumented (will need to hunt for __do_software_count)
-    // TODO: Better way to mark an executable as statically instrumented
+    // Can now do without symbols on x86-64 and aarch64 now !
+    // This is only there to serve as an *additional* way to check if the ELF
+    // file has already been statically instrumented. Newer versions of the
+    // compiler plugin now add a .rr.soft.instrumented section to indicate
+    // that the ELF file has been statically instrumented.
+    // TODO: Consider removing below line in the future.
     SymbolTable syms = reader.read_symbols(".symtab", ".strtab");
+
     t.session().get_or_create_db_of_patch_locations(t, map.map.fsname(), reader,
                                                     syms, unique_id);
   }

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2956,6 +2956,10 @@ static string default_patch_loc_db_save_dir() {
   return cached_dir;
 }
 
+// Increment VERX if cache logic changes (e.g. starting to ignore some conditional
+// branch instructions) or old cache otherwise needs to be ignored
+#define CACHE_VERSION "VER1"
+
 // Has the side effect of creating this dir, if it does not exist already
 string patch_loc_db_save_dir() {
   static string cached_dir;
@@ -2970,6 +2974,9 @@ string patch_loc_db_save_dir() {
   } else {
     cached_dir = default_patch_loc_db_save_dir();
   }
+
+  // append the hardcoded cache version
+  cached_dir += "/" CACHE_VERSION "/";
 
   ensure_dir(cached_dir, "patch location dbs cache dir", S_IRWXU);
 

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -3278,10 +3278,10 @@ RecordSession::cached_data RecordSession::get_or_create_db_of_patch_locations(
 
     // if the section exits, the elf file is instrumented
     if (reader.find_section_file_offsets(".rr.soft.instrumented").start) {
-      LOG(warn) << "`" << fsname
-                << "` seems to be already (statically) software counter "
-                   "instrumented. It will not be considered for "
-                   "dynamic instrumentation";
+      LOG(info) << "`" << fsname
+                << "` is already (statically) software counter "
+                   "instrumented as ELF section .rr.soft.instrumented was found. "
+                   "It will not be considered for dynamic instrumentation";
       already_statically_instrumented = true;
     } else {
       // Older versions of the compiler plugins don't add the .rr.soft.instrumented
@@ -3292,7 +3292,7 @@ RecordSession::cached_data RecordSession::get_or_create_db_of_patch_locations(
       const size_t len = syms.size();
       for (size_t i = 0; i < len; ++i) {
         if (syms.is_name(i, "__do_software_count")) {
-          LOG(warn) << "`" << fsname
+          LOG(info) << "`" << fsname
                     << "` seems to be already (statically) software counter "
                        "instrumented. It will not be considered for "
                        "dynamic instrumentation";


### PR DESCRIPTION
Main change is to modify the gcc and clang compiler plugins so that they add a `rr.soft.instrumented` ELF section. The presence of this section indicates that the ELF file has been statically instrumented with software counter instrumentation.

Another useful change is to allow older caches to be ignored by incrementing CACHE_VERSION. Also other minor changes.
