### PR TITLE
Updated flake.nix to work with recent nixpkgs, GCC 15 and 16 and Clang 20, 21 and 22

### DIFF
--- a/compiler-plugins/SoftwareCountersClangPlugin/README.md
+++ b/compiler-plugins/SoftwareCountersClangPlugin/README.md
@@ -11,7 +11,7 @@ in _Software Counters mode_ `rr`. If your program is not compiled with
 this plugin _Software Counters mode_ `rr` falls back to using dynamic
 instrumentation.
 
-**The plugin can be compiled with `clang` 18, 19, 20 currently**.
+**The plugin can be compiled with `clang` 18, 19, 20, 21, 22 currently**.
 
 The plugin depends on `LLVM` internals. If you compile the plugin
 with `clang` 18 then use the plugin with `clang` 18 only. If you compile

--- a/compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp
+++ b/compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp
@@ -20,7 +20,12 @@
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/PassBuilder.h>
+// https://github.com/llvm/llvm-project/pull/173279
+#if __has_include(<llvm/Plugins/PassPlugin.h>)
+#include <llvm/Plugins/PassPlugin.h>
+#else
 #include <llvm/Passes/PassPlugin.h>
+#endif
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/IR/IRBuilder.h>

--- a/compiler-plugins/SoftwareCountersGccPlugin/README.md
+++ b/compiler-plugins/SoftwareCountersGccPlugin/README.md
@@ -11,7 +11,7 @@ in _Software Counters mode_ `rr`. If your program is not compiled with
 this plugin _Software Counters mode_ `rr` falls back to using dynamic
 instrumentation.
 
-**The plugin can be compiled with gcc 13, gcc 14, gcc 15 currently**.
+**The plugin can be compiled with gcc 13, gcc 14, gcc 15, gcc 16 currently**.
 
 The plugin depends on `gcc` internals. If you compile the plugin with
 `gcc` 13 then use the plugin with `gcc` 13 only. If you compile the

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,7 @@
       ];
       perSystem =
         {
-          config,
-          self',
-          inputs',
+          self,
           pkgs,
           system,
           ...
@@ -28,34 +26,35 @@
             pkgs.rr.overrideAttrs (prev: {
               version = "soft-post5.9.0+builtwith${flavor}";
               src = ./.;
+              # Patch was already applied in commit 6251648873b9e1ed23536beebbaa5d6fead3d5be
+              patches = [ ];
               nativeBuildInputs = [
                 pkgs.ninja
-              ] ++ prev.nativeBuildInputs;
-              buildInputs =
-                [
-                  pkgs.bzip2
-                  pkgs.zstd
-                  pkgs.lz4
-                  pkgs.snappy
-                  pkgs.rocksdb
-                  pkgs.openssl
-                ]
-                ++ pkgs.lib.optionals (system == "x86_64-linux") [ pkgs.zydis ]
-                ++ prev.buildInputs;
+              ]
+              ++ prev.nativeBuildInputs;
+              buildInputs = [
+                pkgs.bzip2
+                pkgs.zstd
+                pkgs.lz4
+                pkgs.snappy
+                pkgs.rocksdb
+                pkgs.openssl
+              ]
+              ++ pkgs.lib.optionals (system == "x86_64-linux") [ pkgs.zydis ]
+              ++ prev.buildInputs;
               # Removed it by overriding in flake -- seems obsolete
               preConfigure = "";
-              # Removed it by overriding in flake -- seems obsolete
-              prePostpatch = "";
               cmakeFlags = prev.cmakeFlags ++ [
                 "-DSOFTWARE_COUNTERS_PLUGIN=${software_counters_plugin}/lib/libSoftwareCounters.so"
+                "-DCMAKE_CXX_STANDARD=20" # rocksdb 10.10.1 requires C++20
                 "-GNinja"
               ];
               dontStrip = true;
             });
           libSoftwareCountersGccFor =
-            ver: gccStdenvArg:
+            gccStdenvArg:
             gccStdenvArg.mkDerivation {
-              pname = "libSoftwareCountersGcc${ver}";
+              pname = "libSoftwareCountersGcc${pkgs.lib.versions.major gccStdenvArg.cc.version}";
               version = "0.1";
               src = ./.;
               dontConfigure = true;
@@ -74,7 +73,6 @@
               meta = {
                 homepage = "https://github.com/sidkshatriya/rr.soft";
                 description = "libSoftwareCountersGcc";
-
                 license = with pkgs.lib.licenses; [
                   gpl3Plus
                 ];
@@ -84,10 +82,10 @@
                 ];
               };
             };
-          libSoftwareCountersFor =
-            ver: clangStdenvArg: llvmPackagesArg:
-            clangStdenvArg.mkDerivation {
-              pname = "libSoftwareCountersClang${ver}";
+          libSoftwareCountersClangFor =
+            llvmPackagesArg:
+            llvmPackagesArg.stdenv.mkDerivation {
+              pname = "libSoftwareCountersClang${pkgs.lib.versions.major llvmPackagesArg.stdenv.cc.version}";
               version = "0.1";
               src = ./.;
               nativeBuildInputs = [
@@ -96,7 +94,7 @@
                 llvmPackagesArg.libllvm
               ];
               cmakeFlags = [
-                ''-S=${./.}/compiler-plugins/SoftwareCountersClangPlugin''
+                "-S=${./.}/compiler-plugins/SoftwareCountersClangPlugin"
                 "-GNinja"
               ];
               installPhase = ''
@@ -110,7 +108,6 @@
               meta = {
                 homepage = "https://github.com/sidkshatriya/rr.soft";
                 description = "libSoftwareCounters";
-
                 license = with pkgs.lib.licenses; [
                   asl20
                 ];
@@ -120,29 +117,48 @@
                 ];
               };
             };
+          # pkgs.rr insists on using pkgs.gccMultiStdenv on x86_64, ignoring plain stdenv override.
+          mkGccMultiStdenv = gccStdenvArg: pkgs.overrideCC gccStdenvArg (pkgs.wrapCCMulti gccStdenvArg.cc);
+          mkClangMultiStdenv =
+            clangStdenvArg: pkgs.overrideCC clangStdenvArg (pkgs.wrapClangMulti clangStdenvArg.cc);
+          mkRrWithGcc =
+            gccStdenvArg:
+            (rr_compiled_with "gcc" (libSoftwareCountersGccFor gccStdenvArg)).override {
+              stdenv = gccStdenvArg;
+              gccMultiStdenv = mkGccMultiStdenv gccStdenvArg;
+            };
+          mkRrWithClang =
+            llvmPackagesArg:
+            (rr_compiled_with "clang" (libSoftwareCountersClangFor llvmPackagesArg)).override {
+              stdenv = llvmPackagesArg.stdenv;
+              gccMultiStdenv = mkClangMultiStdenv llvmPackagesArg.stdenv;
+            };
         in
         {
-          packages.rr-builtwithgcc =
-            (rr_compiled_with "gcc" (libSoftwareCountersGccFor "14" pkgs.gcc14Stdenv)).override
-              {
-                stdenv = pkgs.gcc14Stdenv;
-              };
-          packages.rr-builtwithclang =
-            (rr_compiled_with "clang" (libSoftwareCountersFor "19" pkgs.clang19Stdenv pkgs.llvmPackages_19))
-            .override
-              {
-                stdenv = pkgs.clang19Stdenv;
-              };
-          packages.rr = self'.packages.rr-builtwithclang;
-          packages.libSoftwareCountersGcc14 = (libSoftwareCountersGccFor "14" pkgs.gcc14Stdenv);
-          packages.libSoftwareCountersGcc13 = (libSoftwareCountersGccFor "13" pkgs.gcc13Stdenv);
-          packages.libSoftwareCountersClang19 = (
-            libSoftwareCountersFor "19" pkgs.clang19Stdenv pkgs.llvmPackages_19
-          );
-          packages.libSoftwareCountersClang18 = (
-            libSoftwareCountersFor "18" pkgs.clang18Stdenv pkgs.llvmPackages_18
-          );
-          packages.default = self'.packages.rr;
+          packages = {
+            rr-builtwithgcc = mkRrWithGcc pkgs.gccStdenv;
+            rr-builtwithgcc16 = mkRrWithGcc pkgs.gcc16Stdenv;
+            rr-builtwithgcc15 = mkRrWithGcc pkgs.gcc15Stdenv;
+            rr-builtwithgcc14 = mkRrWithGcc pkgs.gcc14Stdenv;
+            rr-builtwithgcc13 = mkRrWithGcc pkgs.gcc13Stdenv;
+            rr-builtwithclang = mkRrWithClang pkgs.llvmPackages;
+            rr-builtwithclang22 = mkRrWithClang pkgs.llvmPackages_22;
+            rr-builtwithclang21 = mkRrWithClang pkgs.llvmPackages_21;
+            rr-builtwithclang20 = mkRrWithClang pkgs.llvmPackages_20;
+            rr-builtwithclang19 = mkRrWithClang pkgs.llvmPackages_19;
+            rr-builtwithclang18 = mkRrWithClang pkgs.llvmPackages_18;
+            rr = self.packages.rr-builtwithclang;
+            libSoftwareCountersGcc16 = libSoftwareCountersGccFor pkgs.gcc16Stdenv;
+            libSoftwareCountersGcc15 = libSoftwareCountersGccFor pkgs.gcc15Stdenv;
+            libSoftwareCountersGcc14 = libSoftwareCountersGccFor pkgs.gcc14Stdenv;
+            libSoftwareCountersGcc13 = libSoftwareCountersGccFor pkgs.gcc13Stdenv;
+            libSoftwareCountersClang22 = libSoftwareCountersClangFor pkgs.llvmPackages_22;
+            libSoftwareCountersClang21 = libSoftwareCountersClangFor pkgs.llvmPackages_21;
+            libSoftwareCountersClang20 = libSoftwareCountersClangFor pkgs.llvmPackages_20;
+            libSoftwareCountersClang19 = libSoftwareCountersClangFor pkgs.llvmPackages_19;
+            libSoftwareCountersClang18 = libSoftwareCountersClangFor pkgs.llvmPackages_18;
+            default = self.packages.rr;
+          };
         };
     };
 }


### PR DESCRIPTION
- Fixed include in compiler-plugins/SoftwareCountersClangPlugin/SoftwareCounters.cpp for LLVM 22
- Updated README in SoftwareCountersClangPlugin and SoftwareCountersGccPlugin to list Clang 21/22 and GCC 16 as supported
- In flake.nix:
    - Updated inputs
    - Fixed `rr_compiled_with` for recent nixpkgs by removing a patch which was already applied in commit 6251648873b9e1ed23536beebbaa5d6fead3d5be and adding -`DCMAKE_CXX_STANDARD=20` CMake flag required by `pkgs.rocksdb` 10.10.1
    - Replaced `pkgs.clang18Stdenv` and `pkgs.clang19Stdenv` with `pkgs.llvmPackages_18.stdenv` and `pkgs.llvmPackages_19.stdenv` respectively, the `pkgs.clang<version>Stdenv` don't exist for newer Clang versions and `pkgs.llvmPackages_<version>.stdenv` should be used instead
    - Fixed packages rr-builtwithgcc and rr-builtwithclang by adding an override for `gccMultiStdenv` as `pkgs.rr` now insists on using `gccMultiStdenv` on x86_64, ignoring plain `stdenv` override
    - Added `rr-builtwithgcc<GCC version>` and `rr-builtwithclang<Clang version>` packages
    - Cleaned-up and formatted flake.nix